### PR TITLE
HGZ-11 [🔗] - Decorator Nodes 

### DIFF
--- a/How To Survive In That World/Assets/02. Scripts/BehaviorTree/Decorators/Inverter.cs
+++ b/How To Survive In That World/Assets/02. Scripts/BehaviorTree/Decorators/Inverter.cs
@@ -1,0 +1,30 @@
+using System;
+
+// 자식 노드의 상태를 반전시킨다.
+public sealed class Inverter : INode
+{
+    private readonly INode _children;
+
+    public Inverter(INode children)
+    {
+        _children = children;
+    }
+
+    public INode.E_NodeState Evaluate()
+    {
+        if (_children == null)
+            return INode.E_NodeState.ENS_Failure;
+
+        switch (_children.Evaluate())
+        {
+            case INode.E_NodeState.ENS_Running:
+                return INode.E_NodeState.ENS_Running;
+            case INode.E_NodeState.ENS_Success:
+                return INode.E_NodeState.ENS_Failure;
+            case INode.E_NodeState.ENS_Failure:
+                return INode.E_NodeState.ENS_Success;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+    }
+}

--- a/How To Survive In That World/Assets/02. Scripts/BehaviorTree/Decorators/Inverter.cs.meta
+++ b/How To Survive In That World/Assets/02. Scripts/BehaviorTree/Decorators/Inverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 590ed3d7bd5d211448a6849c5611515b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/How To Survive In That World/Assets/02. Scripts/BehaviorTree/Decorators/Repeat.cs
+++ b/How To Survive In That World/Assets/02. Scripts/BehaviorTree/Decorators/Repeat.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 
 // 자식 노드의 상태에 상관없이 지정된 횟수만큼 반복하고 완료 후 Success를 반환.
-// 추후 적용 후 리팩토링 진행예정.
+// 추후 적용과 실험 후 리팩토링 진행예정.
 public sealed class Repeat : INode
 {
     private readonly INode _children;
@@ -22,6 +22,7 @@ public sealed class Repeat : INode
         // 지정된 횟수만큼 반복
         if (_currentCount < _repeatCount)
         {
+            _children.Evaluate();
             _currentCount++;
 
             return INode.E_NodeState.ENS_Running;

--- a/How To Survive In That World/Assets/02. Scripts/BehaviorTree/Decorators/Repeat.cs
+++ b/How To Survive In That World/Assets/02. Scripts/BehaviorTree/Decorators/Repeat.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 
 // 자식 노드의 상태에 상관없이 지정된 횟수만큼 반복하고 완료 후 Success를 반환.
 // 추후 적용 후 리팩토링 진행예정.
-public class Repeat : MonoBehaviour
+public sealed class Repeat : INode
 {
     private readonly INode _children;
 

--- a/How To Survive In That World/Assets/02. Scripts/BehaviorTree/Decorators/Repeat.cs
+++ b/How To Survive In That World/Assets/02. Scripts/BehaviorTree/Decorators/Repeat.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+
+// 자식 노드의 상태에 상관없이 지정된 횟수만큼 반복하고 완료 후 Success를 반환.
+// 추후 적용 후 리팩토링 진행예정.
+public class Repeat : MonoBehaviour
+{
+    private readonly INode _children;
+
+    private int _repeatCount;
+    private int _currentCount = 0;
+
+    public Repeat(INode children)
+    {
+        _children = children;
+    }
+
+    public INode.E_NodeState Evaluate()
+    {
+        if (_children == null)
+            return INode.E_NodeState.ENS_Failure;
+        
+        // 지정된 횟수만큼 반복
+        if (_currentCount < _repeatCount)
+        {
+            _currentCount++;
+
+            return INode.E_NodeState.ENS_Running;
+        }
+        else
+        {
+            _currentCount = 0;
+            return INode.E_NodeState.ENS_Success;
+        }
+    }
+}

--- a/How To Survive In That World/Assets/02. Scripts/BehaviorTree/Decorators/Repeat.cs.meta
+++ b/How To Survive In That World/Assets/02. Scripts/BehaviorTree/Decorators/Repeat.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0aee169981dba794f94449bc79ab7b3c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/How To Survive In That World/Assets/02. Scripts/BehaviorTree/Decorators/Succeed.cs
+++ b/How To Survive In That World/Assets/02. Scripts/BehaviorTree/Decorators/Succeed.cs
@@ -4,15 +4,5 @@ using UnityEngine;
 
 public class Succeed : MonoBehaviour
 {
-    // Start is called before the first frame update
-    void Start()
-    {
-        
-    }
 
-    // Update is called once per frame
-    void Update()
-    {
-        
-    }
 }

--- a/How To Survive In That World/Assets/02. Scripts/BehaviorTree/Decorators/Succeed.cs
+++ b/How To Survive In That World/Assets/02. Scripts/BehaviorTree/Decorators/Succeed.cs
@@ -1,8 +1,32 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+using System;
 
-public class Succeed : MonoBehaviour
+// 자식의 상태에 상관없이 항상 성공을 반환한다.
+// 고장이 예상되는 분기의 테스트 처리용.
+// 반대는 Inverter를 이용해 처리.
+public sealed class Succeed : INode
 {
+    private readonly INode _children;
 
+    public Succeed(INode children)
+    {
+        _children = children;
+    }
+
+    public INode.E_NodeState Evaluate()
+    {
+        if (_children == null)
+            return INode.E_NodeState.ENS_Failure;
+
+        switch (_children.Evaluate())
+        {
+            case INode.E_NodeState.ENS_Running:
+                return INode.E_NodeState.ENS_Success;
+            case INode.E_NodeState.ENS_Success:
+                return INode.E_NodeState.ENS_Success;
+            case INode.E_NodeState.ENS_Failure:
+                return INode.E_NodeState.ENS_Success;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+    }
 }

--- a/How To Survive In That World/Assets/02. Scripts/BehaviorTree/Decorators/Succeed.cs
+++ b/How To Survive In That World/Assets/02. Scripts/BehaviorTree/Decorators/Succeed.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Succeed : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/How To Survive In That World/Assets/02. Scripts/BehaviorTree/Decorators/Succeed.cs.meta
+++ b/How To Survive In That World/Assets/02. Scripts/BehaviorTree/Decorators/Succeed.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 589689d4d9e1b6d419abab4b9629ff45
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/How To Survive In That World/Assets/02. Scripts/BehaviorTree/Decorators/UntilFail.cs
+++ b/How To Survive In That World/Assets/02. Scripts/BehaviorTree/Decorators/UntilFail.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class UntilFail : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/How To Survive In That World/Assets/02. Scripts/BehaviorTree/Decorators/UntilFail.cs
+++ b/How To Survive In That World/Assets/02. Scripts/BehaviorTree/Decorators/UntilFail.cs
@@ -1,18 +1,28 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
+// 자식 노드가 실패를 반환할 때까지 계속해서 재검사 하는 데코레이터 노드.
+// 실패를 반환하면 성공을 반환한다.
 public class UntilFail : MonoBehaviour
 {
-    // Start is called before the first frame update
-    void Start()
+    private readonly INode _children;
+
+    public UntilFail(INode children)
     {
-        
+        _children = children;
     }
 
-    // Update is called once per frame
-    void Update()
+    public INode.E_NodeState Evaluate()
     {
+        if (_children == null)
+            return INode.E_NodeState.ENS_Failure;
+
+        INode.E_NodeState children = _children.Evaluate();
+
+        if (children == INode.E_NodeState.ENS_Failure)
+        {
+            return INode.E_NodeState.ENS_Success;
+        }
         
+        return INode.E_NodeState.ENS_Running;
     }
 }

--- a/How To Survive In That World/Assets/02. Scripts/BehaviorTree/Decorators/UntilFail.cs
+++ b/How To Survive In That World/Assets/02. Scripts/BehaviorTree/Decorators/UntilFail.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 
 // 자식 노드가 실패를 반환할 때까지 계속해서 재검사 하는 데코레이터 노드.
 // 실패를 반환하면 성공을 반환한다.
-public class UntilFail : MonoBehaviour
+public sealed class UntilFail : INode
 {
     private readonly INode _children;
 

--- a/How To Survive In That World/Assets/02. Scripts/BehaviorTree/Decorators/UntilFail.cs.meta
+++ b/How To Survive In That World/Assets/02. Scripts/BehaviorTree/Decorators/UntilFail.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e3c56a334c6b6114d8e8374ff198fad9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Decorator Nodes

## Inverter Node
- 자식 노드의 상태를 반전시킨다.
- 성공이면 실패를, 실패면 성공을

## Repeat Node
- 자식 노드의 상태에 상관없이 지정된 횟수만큼 Running을 반복하고 횟수가 완료되면 Success를 반환한다.
- 추후 적용하며 리팩토링 예정.

## Until Fail Node
- 자식 노드가 실패를 반환할 때까지 계속해서 재검사를 진행한다.
- 실패를 반환하면 성공을 반환한다.

## Succeed Node
- 자식의 상태에 상관없이 항상 성공을 반환.
- 고장이 예상되는 분기의 테스트 처리
- 반대는 Inverter를 이용


# 수정 사항

## Until Fail, Reapeat
- INode 상속 추가
- sealed 보호타입 추가

-# Repeat Node 누락
- 실행 로직(Evaluate())가 누락되어 추가.